### PR TITLE
Fix schema when then otherwise

### DIFF
--- a/src/conditions/when/when-entry.js
+++ b/src/conditions/when/when-entry.js
@@ -1,182 +1,177 @@
 function isObjectType(obj) {
-  return obj === Object(obj);
+    return obj === Object(obj);
 }
 
 function isStringType(val) {
-  return typeof val === "string";
+    return typeof val === 'string';
 }
 
 export class WhenEntry {
-  constructor(whenEntryObj, opts = {}) {
-    this.whenEntryObj = whenEntryObj;
-    const { schema, properties, config, key, keys, when, type } = opts;
-    this.schema = schema;
-    this.when = when;
-    this.properties = properties || {};
-    this.key = key;
-    // this.whenKeys = (when ? Object.keys(when) : keys) || [];
-    this.type = type;
-    this.config = config;
-  }
-
-  // keysArePresent(keys) {
-  //   const whenKeys = this.whenKeys;
-  //   return keys.every(key => !!whenKeys.includes(key));
-  // }
-
-  validateAndConfigure(whenEntryObj) {
-    whenEntryObj = whenEntryObj || this.whenEntryObj;
-    if (!isObjectType(whenEntryObj)) {
-      this.warn(
-        "invalid or missing when entry constraint object",
-        whenEntryObj
-      );
-      return false;
+    constructor(whenEntryObj, opts = {}) {
+        this.whenEntryObj = whenEntryObj;
+        const { schema, properties, config, key, keys, when, type } = opts;
+        this.schema = schema;
+        this.when = when;
+        this.properties = properties || {};
+        this.key = key;
+        // this.whenKeys = (when ? Object.keys(when) : keys) || [];
+        this.type = type;
+        this.config = config;
     }
 
-    const whenEntryKeys = Object.keys(whenEntryObj);
-
-    if (whenEntryKeys.length < 2) {
-      this.warn(
-        `validateAndConfigure: when entry constraint must have at least 2 keys: ${whenEntryKeys}`,
-        whenEntryObj
-      );
-      return false;
-    }
-
-    // must have is condition
-    if (!this.hasKey(whenEntryKeys, "is")) {
-      this.warn(
-        `validateAndConfigure: when entry constraint missing 'is' constraint: ${whenEntryKeys}`,
-        whenEntryObj
-      );
-      return false;
-    }
-
-    // must have then condition
-    if (!this.hasKey(whenEntryKeys, "then")) {
-      this.warn(
-        `validateAndConfigure: when entry constraint missing 'then' or 'else' constraint: ${whenEntryKeys}`,
-        whenEntryObj
-      );
-      return false;
-    }
-
-    // this.whenEntryKeys = this.keys || [];
-    // this.whenEntryKeysPresent = this.keysArePresent(this.whenEntryKeys);
-
-    return true;
-  }
-
-  createYupSchemaEntry(opts) {
-    return this.config.createYupSchemaEntry(opts);
-  }
-
-  createValue(entryObj, key) {
-    if (typeof entryObj === "string") {
-      entryObj = {
-        [entryObj]: true
-      };
-    }
-    if (!isObjectType(entryObj)) {
-      this.error(`createValue: ${key} must be a schema object`);
-    }
-    return {
-      key: this.key,
-      type: this.type,
-      ...entryObj
-    };
-  }
-
-  createEntryOpts(entryObj, whenKey) {
-    // recursive apply then object
-    const value = this.createValue(entryObj, whenKey);
-    return {
-      schema: this.schema,
-      properties: this.properties,
-      key: this.key,
-      type: this.type,
-      value,
-      config: this.config
-    };
-  }
-
-  createEntry(entryObj, whenKey) {
-    const opts = this.createEntryOpts(entryObj, whenKey);
-    return this.createYupSchemaEntry(opts);
-  }
-
-  hasKey(keys, findKey) {
-    return keys.find(key => key === findKey);
-  }
-
-  hasAnyKey(keys, findKeys) {
-    return keys.find(key => findKeys.includes(key));
-  }
-
-  // checkIs(is, present) {
-  //   present = present || this.whenEntryKeysPresent;
-  //   const checked = (is === true && present) || (is === false && !present);
-  //   // const keys = this.whenEntryKeys;
-  //   return checked;
-  // }
-
-  whenEntryFor(whenObj, createEntryKey, whenKey) {
-    whenKey = whenKey || createEntryKey;
-
-    if (isStringType(whenObj)) {
-      whenObj = {
-        [whenObj]: true
-      };
-    }
-
-    if (!isObjectType(whenObj)) {
-      throw `whenEntryFor: Invalid when object ${whenObj}`;
-    }
-
-    // clone
-    const entryDef = {
-      ...whenObj[whenKey]
-    };
-    delete whenObj[whenKey];
-    if (!entryDef) return whenObj;
-    whenObj[createEntryKey] = this.createEntry(entryDef, createEntryKey);
-    return whenObj;
-  }
-
-  calcEntryObj() {
-    // clone
-    let whenEntryObj = {
-      ...this.whenEntryObj
-    };
-
-    // const { is } = whenEntryObj;
-    // const checkedIs = this.checkIs(is);
-    // if (!checkedIs) {
-    //   this.warn(`calcEntryObj: missing or invalid is constraint`, is);
-    //   return whenEntryObj;
+    // keysArePresent(keys) {
+    //   const whenKeys = this.whenKeys;
+    //   return keys.every(key => !!whenKeys.includes(key));
     // }
-    const otherwiseKey = whenEntryObj.then ? "else" : "otherwise";
 
-    whenEntryObj = this.whenEntryFor(whenEntryObj, "then");
-    whenEntryObj = this.whenEntryFor(whenEntryObj, "otherwise", otherwiseKey);
-    return whenEntryObj;
-  }
+    validateAndConfigure(whenEntryObj) {
+        whenEntryObj = whenEntryObj || this.whenEntryObj;
+        if (!isObjectType(whenEntryObj)) {
+            this.warn(
+                'invalid or missing when entry constraint object',
+                whenEntryObj
+            );
+            return false;
+        }
 
-  get entryObj() {
-    return this.validateAndConfigure() && this.calcEntryObj();
-  }
+        const whenEntryKeys = Object.keys(whenEntryObj);
 
-  warn(msg, value) {
-    console.error("[WhenEntry] WARNING", msg, value);
-  }
+        if (whenEntryKeys.length < 2) {
+            this.warn(
+                `validateAndConfigure: when entry constraint must have at least 2 keys: ${whenEntryKeys}`,
+                whenEntryObj
+            );
+            return false;
+        }
 
-  error(msg, value) {
-    console.error("[WhenEntry] ERROR", msg, value);
-    throw msg;
-  }
+        // must have is condition
+        if (!this.hasKey(whenEntryKeys, 'is')) {
+            this.warn(
+                `validateAndConfigure: when entry constraint missing 'is' constraint: ${whenEntryKeys}`,
+                whenEntryObj
+            );
+            return false;
+        }
+
+        // must have then condition
+        if (!this.hasKey(whenEntryKeys, 'then')) {
+            this.warn(
+                `validateAndConfigure: when entry constraint missing 'then' or 'else' constraint: ${whenEntryKeys}`,
+                whenEntryObj
+            );
+            return false;
+        }
+
+        // this.whenEntryKeys = this.keys || [];
+        // this.whenEntryKeysPresent = this.keysArePresent(this.whenEntryKeys);
+
+        return true;
+    }
+
+    createYupSchemaEntry(opts) {
+        return this.config.createYupSchemaEntry(opts);
+    }
+
+    createValue(entryObj, key) {
+        if (typeof entryObj === 'string') {
+            entryObj = {
+                [entryObj]: true
+            };
+        }
+        if (!isObjectType(entryObj)) {
+            this.error(`createValue: ${key} must be a schema object`);
+        }
+        return {
+            key: this.key,
+            type: this.type,
+            ...entryObj
+        };
+    }
+
+    createEntryOpts(entryObj, whenKey) {
+        // recursive apply then object
+        const value = this.createValue(entryObj, whenKey);
+        return {
+            schema: this.schema,
+            properties: this.properties,
+            key: this.key,
+            type: this.type,
+            value,
+            config: this.config
+        };
+    }
+
+    createEntry(entryObj, whenKey) {
+        const opts = this.createEntryOpts(entryObj, whenKey);
+        return this.createYupSchemaEntry(opts);
+    }
+
+    hasKey(keys, findKey) {
+        return keys.find(key => key === findKey);
+    }
+
+    hasAnyKey(keys, findKeys) {
+        return keys.find(key => findKeys.includes(key));
+    }
+
+    // checkIs(is, present) {
+    //   present = present || this.whenEntryKeysPresent;
+    //   const checked = (is === true && present) || (is === false && !present);
+    //   // const keys = this.whenEntryKeys;
+    //   return checked;
+    // }
+
+    whenEntryFor(whenObj, createEntryKey, whenKey) {
+        whenKey = whenKey || createEntryKey;
+
+        if (isStringType(whenObj)) {
+            whenObj = {
+                [whenObj]: true
+            };
+        }
+
+        if (!isObjectType(whenObj)) {
+            throw `whenEntryFor: Invalid when object ${whenObj}`;
+        }
+
+        // clone
+        const entryDef = {
+            ...whenObj[whenKey]
+        };
+        delete whenObj[whenKey];
+        if (!entryDef) return whenObj;
+        whenObj[createEntryKey] = this.createEntry(entryDef, createEntryKey);
+        return whenObj;
+    }
+
+    calcEntryObj() {
+        let newEntry = {
+            ...this.whenEntryObj
+        };
+        newEntry = this.whenEntryFor(newEntry, 'then');
+        if ('otherwise' in newEntry) {
+            newEntry = this.whenEntryFor(newEntry, 'otherwise');
+        }
+        if ('else' in newEntry) {
+            newEntry = this.whenEntryFor(newEntry, 'else');
+        }
+        return newEntry;
+    }
+
+    get entryObj() {
+        return this.validateAndConfigure() && this.calcEntryObj();
+    }
+
+    warn(msg, value) {
+        console.error('[WhenEntry] WARNING', msg, value);
+    }
+
+    error(msg, value) {
+        console.error('[WhenEntry] ERROR', msg, value);
+        throw msg;
+    }
 }
 
 export const createWhenEntry = (whenEntry, opts = {}) => {
-  return new WhenEntry(whenEntry, opts);
+    return new WhenEntry(whenEntry, opts);
 };

--- a/src/types/mixed/mixed.js
+++ b/src/types/mixed/mixed.js
@@ -145,10 +145,6 @@ class YupMixed extends Base {
     });
   }
 
-<<<<<<< HEAD
-  addConstraint(propName, opts) {
-    return this.constraintBuilder.addConstraint(propName, opts);
-=======
   get aliasMap() {
     return {
       oneOf: "oneOf",
@@ -284,7 +280,6 @@ class YupMixed extends Base {
   onConstraintAdded({ name, value }) {
     this.constraintsAdded[name] = value;
     return this;
->>>>>>> e4e96f817c0243214eeef1ef194dea28db4c4872
   }
 
   addMappedConstraints() {

--- a/test/schema-when-then-otherwise.test.js
+++ b/test/schema-when-then-otherwise.test.js
@@ -1,85 +1,83 @@
-const { buildYup } = require("../");
+const { buildYup } = require('../');
 
-describe("when", () => {
-  const createTester = schema => {
-    return (json, expectedResult) => {
-      const valid = schema.isValidSync(json);
-      // console.log({ json, valid, expectedResult });
-      expect(valid).toBe(expectedResult);
+describe('when', () => {
+    const createTester = schema => {
+        return (json, expectedResult) => {
+            const valid = schema.isValidSync(json);
+            expect(valid).toBe(expectedResult);
+        };
     };
-  };
 
-  describe("then otherwise", () => {
-    const whenThenOtherwisejson = {
-      title: "user",
-      type: "object",
-      properties: {
-        isBig: {
-          type: "string",
-          min: 1
-        },
-        level: {
-          type: "number",
-          required: true,
-          when: {
-            isBig: {
-              is: true,
-              then: {
-                min: 2
-              },
-              otherwise: {
-                min: 10
-              }
+    describe('then otherwise', () => {
+        const whenThenOtherwisejson = {
+            title: 'user',
+            type: 'object',
+            properties: {
+                isBig: {
+                    type: 'string'
+                },
+                level: {
+                    type: 'number',
+                    when: {
+                        isBig: {
+                            is: true,
+                            then: {
+                                min: 2
+                            },
+                            otherwise: {
+                                min: 10
+                            }
+                        }
+                    }
+                }
             }
-          }
-        }
-      }
-    };
+        };
+        const $json = {
+            isBig: {
+                valid: {
+                    isBig: 'x',
+                    level: 10
+                },
+                invalid: {
+                    isBig: 'x',
+                    level: 0
+                }
+            },
+            isNotBig: {
+                valid: {
+                    isBig: '',
+                    level: 10
+                },
+                invalid: {
+                    isBig: '',
+                    level: 0
+                }
+            }
+        };
+        const yupSchema = buildYup(whenThenOtherwisejson);
+        const tester = createTester(yupSchema);
 
-    const $json = {
-      isBig: {
-        valid: {
-          isBig: "x",
-          level: 3
-        },
-        invalid: {
-          isBig: "x",
-          level: 0
-        }
-      },
-      isNotBig: {
-        isBig: "",
-        age: 3
-      },
-      invalid: {
-        isBig: "",
-        level: 0
-      }
-    };
+        describe('isBig', () => {
+            const json = $json.isBig;
+            test('should be valid', () => {
+                tester(json.valid, true);
+                //Note: the min value of `then` must also be larger
+                //than the min value of `otherwise`.
+            });
+            test('should be invalid', () => {
+                tester(json.invalid, false);
+            });
+        });
 
-    const yupSchema = buildYup(whenThenOtherwisejson);
-    const tester = createTester(yupSchema);
+        describe('isNotBig', () => {
+            const json = $json.isNotBig;
+            test('should be valid', () => {
+                tester(json.valid, true);
+            });
 
-    describe("isBig", () => {
-      const json = $json.isBig;
-      test("valid", () => {
-        tester(json.valid, true);
-      });
-
-      test("valid", () => {
-        tester(json.invalid, false);
-      });
+            test('should be invalid', () => {
+                tester(json.invalid, false);
+            });
+        });
     });
-
-    describe("isNotBig", () => {
-      const json = $json.isNotBig;
-      test("valid", () => {
-        tester(json.valid, true);
-      });
-
-      test("valid", () => {
-        tester(json.invalid, false);
-      });
-    });
-  });
 });


### PR DESCRIPTION
My formatter has seemed to made this PR bigger than it seems, apologies for that.

This PR is to fix the `else` and `otherwise` condition in the WhenEntry class.  The existing code seemed to suggest that when 'then' prop is  truthy then 'else' is optionally available however this meant that 'otherwise' will never be met.

```
    calcEntryObj() {
        let newEntry = {
            ...this.whenEntryObj
        };
        newEntry = this.whenEntryFor(newEntry, 'then');
        if ('otherwise' in newEntry) {
            newEntry = this.whenEntryFor(newEntry, 'otherwise');
        }
        if ('else' in newEntry) {
            newEntry = this.whenEntryFor(newEntry, 'else');
        }
        return newEntry;
    }
```