### PR TITLE
Fix presentConstraintValue validator handler

### DIFF
--- a/src/constraint-builder.js
+++ b/src/constraint-builder.js
@@ -21,6 +21,7 @@ export class ConstraintBuilder extends TypeMatcher {
       propValue,
       method,
       yup,
+      value,
       values,
       errName
     } = opts;
@@ -65,7 +66,7 @@ export class ConstraintBuilder extends TypeMatcher {
     ];
     let newBase;
     for (let name of constrainFnNames) {
-      newBase = this[name](values, constrOpts);
+      newBase = this[name](value || values, constrOpts);
       if (newBase) break;
     }
 


### PR DESCRIPTION
For the range constraints (min, max) field value isn't being passed to the constraint validator and it always calling `nonPresentConstraintValue` constraint handler which is wrong as well as for the other scalar values where `this.addConstraint(name, { method, value });` is used.

Schema

```
{"core_tickets_lock_lifetime":{"type":"number","min":900}}
{"errMessages":{"core_tickets_lock_lifetime":{"min":"admin.validation.minimum_lock_duration"}}}
```

See attached screenshots before and after the fix

![Screenshot 2021-10-27 at 13 47 27](https://user-images.githubusercontent.com/1681915/139051706-3ad5fc0f-f360-4d17-8845-03c1925b6dad.png)

![Screenshot 2021-10-27 at 13 38 18](https://user-images.githubusercontent.com/1681915/139051725-5c8ec23c-b59b-4942-ade0-008bec6c057c.png)


