### PR TITLE
fix(array): `itemsOf` resinstantiation

### DIFF
--- a/src/types/array/array.js
+++ b/src/types/array/array.js
@@ -29,7 +29,7 @@ export class YupArray extends YupMixed {
   }
 
   get typeEnabled() {
-    return ["maxItems", "minItems", "ensureItems", "compact", "itemsOf"];
+    return ["itemsOf", "maxItems", "minItems", "ensureItems", "compact"];
   }
 
   ensureItems() {

--- a/test/types/array/array.test.js
+++ b/test/types/array/array.test.js
@@ -22,9 +22,9 @@ const createArrNoKey = (value, config = defaultConfig) => {
   return toYupArray(obj, config);
 };
 
-const createSchema = list => {
+const createSchema = (list) => {
   return yup.object().shape({
-    list
+    list,
   });
 };
 
@@ -122,7 +122,7 @@ describe("toYupArray", () => {
 
   describe("itemsOf", () => {
     describe("schema opts", () => {
-      test.skip("type: number - ok", () => {
+      test("type: number - ok", () => {
         expect(() => createArr({ itemsOf: { type: "number" } })).not.toThrow();
         try {
           createArr({ itemsOf: { type: "number" } });
@@ -136,7 +136,7 @@ describe("toYupArray", () => {
       });
     });
 
-    describe.skip("manual simple validate", () => {
+    describe("manual simple validate", () => {
       const constraint = yup.number().min(2);
       const schema = yup.array().of(constraint);
 
@@ -150,11 +150,11 @@ describe("toYupArray", () => {
       });
     });
 
-    describe.skip("manual schema validate", () => {
+    describe("manual schema validate", () => {
       const constraint = yup.number().min(2);
 
       const schema = yup.object().shape({
-        list: yup.array().of(constraint)
+        list: yup.array().of(constraint),
       });
 
       test("valid", () => {
@@ -167,7 +167,7 @@ describe("toYupArray", () => {
       });
     });
 
-    describe.skip("validate", () => {
+    describe("validate", () => {
       const arr = createArr({ itemsOf: { type: "number", min: 2 } });
       const schema = createSchema(arr);
 
@@ -176,7 +176,7 @@ describe("toYupArray", () => {
         expect(valid).toBeTruthy();
       });
 
-      test.skip("invalid", () => {
+      test("invalid", () => {
         const valid = schema.isValidSync({ list: [1, "yb", {}] });
         expect(valid).toBeFalsy();
       });

--- a/test/types/array/array.test.js
+++ b/test/types/array/array.test.js
@@ -1,4 +1,4 @@
-const { types } = require("../../../src");
+const { types, buildYup } = require("../../../src");
 const { toYupArray } = types;
 const { createYupSchemaEntry } = require("../../../src/create-entry");
 import schemaParserMaps from "../../../src/types/schema-parser-maps";
@@ -177,9 +177,31 @@ describe("toYupArray", () => {
       });
 
       test("invalid", () => {
-        const valid = schema.isValidSync({ list: [1, "yb", {}] });
+        const valid = schema.isValidSync({ list: [1, "yb"] });
         expect(valid).toBeFalsy();
       });
     });
+  });
+
+  describe("combined", () => {
+    describe("schema opts", () => {
+      test("type: number - ok", () => {
+        expect(() =>
+          createArr({ itemsOf: { type: "number" }, min: 1, max: 3 })
+        ).not.toThrow();
+      });
+    });
+
+    describe("schema opts", () => {
+      test("type: number - ok", () => {
+        const schema = createSchema(
+          createArr({ itemsOf: { type: "number" }, min: 1, max: 3 })
+        );
+        expect(schema.isValidSync([])).toBeFalsy();
+        expect(schema.isValidSync(["definetely not a number"])).toBeFalsy();
+        expect(schema.isValidSync([1, 2, 3, 4])).toBeFalsy();
+      });
+    });
+    buildYup
   });
 });

--- a/test/yup-builder.spec.js
+++ b/test/yup-builder.spec.js
@@ -1,0 +1,50 @@
+const { buildYup } = require("../src");
+
+describe("buildYup", () => {
+  describe("type: 'array'", () => {
+    const innerSchema = {
+      properties: {
+        testArray: {
+          type: "array",
+          min: 1,
+          max: 3,
+          items: {
+            type: "number",
+          },
+        },
+      },
+      type: "object",
+    };
+
+    let testSchema, config, schema;
+    beforeEach(() => {
+      testSchema = {
+        $schema: "http://json-schema.org/draft-07/schema#",
+        $id: "test_id",
+        title: "array",
+        type: "object",
+        ...innerSchema,
+      };
+
+      config = {
+        // logging: true,
+      };
+      schema = buildYup(testSchema, config);
+    });
+
+    test("validates array", () => {
+      expect(() => {
+        schema.validateSync({ testArray: [] });
+      }).toThrow();
+      expect(() => {
+        schema.validateSync({ testArray: [1, 2, 3, 4] });
+      }).toThrow();
+      expect(() => {
+        schema.validateSync({ testArray: [1, "a"] });
+      }).toThrow();
+      expect(() => {
+        schema.validateSync({ testArray: [1, 2] });
+      }).not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
Hello,

First of all, thank you for your work on this package!
I have been trying to take this into use but found that there are issues with arrays implementation. Saw the disclaimer [here](https://github.com/kristianmandrup/schema-to-yup#1211-custom-array-type-handler) but it seems that the bug present in current functionality

From what I could understand, when `YupMixed` was setting up properties it uses `convertEnabled` which takes target's enabled types and incrementally adds constraints onto the instance. 

In case of 'array' type one of those is `itemsOf`. When it was getting to that part, array validator instance was recreated all previously set constraints are lost (min/max was not validated). This behavior could only be observed when you build schema with `buildYup` and not verify it `array.js` scoped unit test.

Not sure that reordering return of `typesEnabled` is the best way to fix it but seems to do the trick (you can check new `buildYup` test, this was failing before that change)