### PR TITLE
fix: refValueFor error messages

### DIFF
--- a/src/types/mixed/mixed.js
+++ b/src/types/mixed/mixed.js
@@ -371,11 +371,16 @@ class YupMixed extends Base {
     if (this.isNothing(propRefName)) return this;
     this.logInfo("refValueFor", { propRefName });
     return this.apply(
-      "when",
-      (propRefName,
-      (refValueFor, field) =>
-        refValueFor ? field.required().oneOf([yup.ref(propRefName)]) : field)
-    );
+        "when",
+        (propRefName,
+            (refValueFor, field) => {
+              const errorText = this.errMessages[this.key].refValueFor
+              if (errorText) {
+                return refValueFor ? field.required().oneOf([yup.ref(propRefName)], errorText) : field
+              }
+              return refValueFor ? field.required().oneOf([yup.ref(propRefName)]) : field
+            })
+    )
   }
 
   normalizeValues(values) {

--- a/test/confirm-password.test.js
+++ b/test/confirm-password.test.js
@@ -40,11 +40,28 @@ describe("Login form schema using refValue for confirmPassword property", () => 
       // for error messages...
       errMessages: {
         confirmPassword: {
-          required: "confirm password field must have the same value as password"
+          refValueFor: "confirm password field must have the same value as password",
+          required: "this field is required"
         }
       }
     };
     schema = buildYup(loginSchema, config);
+  })
+
+    it('is invalid if blank and displays correct message', async () => {
+    try {
+      schema.validateSync({ username: "jimmy", "password": "xyz123", "confirmPassword": "" });
+    } catch (e) {
+      expect(e.errors[0]).toBe('this field is required');
+    }
+  })
+
+  it('is invalid if if confirmPassword does not match password', async () => {
+    try {
+      schema.validateSync({ username: "jimmy", "password": "xyz123", "confirmPassword": "xyz1234" });
+    } catch (e) {
+      expect(e.errors[0]).toBe('confirm password field must have the same value as password');
+    }
   })
 
   it('is invalid with invalid data', async () => {


### PR DESCRIPTION
- refValueFor currently ignores the bespoke errMessages and returns: confirmPassword must be one of the following values: Ref(password)
- added in a check to see if the message exists, if so then return the custom error, if not carry on as normal
- updated confirm-password.test.js, this is a good example of having multiple errors, required should display one error message and if it does not match the password should display another