### PR TITLE
[fixes #145] Fix error messages defined in Schema

### DIFF
--- a/src/error-message-handler.js
+++ b/src/error-message-handler.js
@@ -40,7 +40,7 @@ export class ErrorMessageHandler extends TypeMatcher {
     const { value } = typeHandler;
     if (!value.errMessage && !value.errMessages) return;
     const valueKey = this.errMessageKey;
-    this.errMessages = { [this.key]: this.errMessageMap(value)};
+    this.errMessages = value[valueKey] || {[this.key]: this.errMessageMap(value)};
     return;
   }
 

--- a/src/error-message-handler.js
+++ b/src/error-message-handler.js
@@ -10,7 +10,7 @@ export class ErrorMessageHandler extends TypeMatcher {
   init() {
     const { typeHandler } = this;
     this.constraints = typeHandler.constraints;
-    this.errMessages = typeHandler.errMessages
+    this.errMessages = typeHandler.errMessages;
     this.key = typeHandler.key;
     this.value = typeHandler.value; // raw type constraints
     this.constraints = typeHandler.constraints; // type constraints (possibly filtered)

--- a/src/error-message-handler.js
+++ b/src/error-message-handler.js
@@ -10,7 +10,7 @@ export class ErrorMessageHandler extends TypeMatcher {
   init() {
     const { typeHandler } = this;
     this.constraints = typeHandler.constraints;
-    this.errMessages = typeHandler.errMessages;
+    this.errMessages = typeHandler.errMessages
     this.key = typeHandler.key;
     this.value = typeHandler.value; // raw type constraints
     this.constraints = typeHandler.constraints; // type constraints (possibly filtered)
@@ -38,11 +38,10 @@ export class ErrorMessageHandler extends TypeMatcher {
   setErrMessage() {
     const { typeHandler } = this;
     const { value } = typeHandler;
-    if (!value.errMessage) return;
+    if (!value.errMessage && !value.errMessages) return;
     const valueKey = this.errMessageKey;
-    const errMessageMap = this.errMessageMap(value);
-    errMessageMap[this.key] = value[valueKey] || errMessageMap[this.key];
-    return this;
+    this.errMessages = { [this.key]: this.errMessageMap(value)};
+    return;
   }
 
   validationErrorMessage(msgName) {


### PR DESCRIPTION
Fixes https://github.com/kristianmandrup/schema-to-yup/issues/145

I modified the `setErrMessage` function. I believe a check for `errMessages` was missing to parse that key if present. in the schema. I also had to change the parsing of `errMessages` slightly to ensure it was in the form outlined in the docs.

Schema for example `length` property:
```
{
    "type": "number",
    "minimum": 1,
    "maximum": 10,
    "default": 5,
    "errMessages": {
        "minimum": "Value must be greater than 1 and less than 10",
        "maximum": "Value must be less than 10 and greater than 1"
    },
}
```
Will produce an `ErrorMessageHandler.errMessages` value of:
```
{
    "length": {
        "minimum": "Value must be greater than 1 and less than 10",
        "maximum": "Value must be less than 10 and greater than 1"
    }
}
```

Seems to work great for me, custom errors are showing in forms during validation. Defining error messages directly in schema is very clean for my application since I already dynamically modify the schema and can add them easily.

I would just confirm this does not break functionality for folks using the `errMessage` key in their schema/config.